### PR TITLE
Add function for api result format, fix bug of db context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 echosample
 *.db
+tmp

--- a/controllers/discount_api.go
+++ b/controllers/discount_api.go
@@ -27,9 +27,7 @@ func (DiscountApiController) GetAll(c echo.Context) error {
 
 	var v SearchInput
 	if err := c.Bind(&v); err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	if v.MaxResultCount == 0 {
 		v.MaxResultCount = DefaultMaxResultCount
@@ -49,107 +47,71 @@ func (DiscountApiController) GetAll(c echo.Context) error {
 
 	totalCount, items, err := models.Discount{}.GetAll(c.Request().Context(), v.Sortby, v.Order, v.SkipCount, v.MaxResultCount)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
 	}
 	tracer.LogFields(
 		log.String("Action", "Search From DB"),
 		log.Int64("TotalCount", totalCount),
 	)
-	return c.JSON(http.StatusOK, ApiResult{
-		Success: true,
-		Result: ArrayResult{
-			TotalCount: totalCount,
-			Items:      items,
-		},
+	return ReturnApiSucc(c, http.StatusOK, ArrayResult{
+		TotalCount: totalCount,
+		Items:      items,
 	})
 }
 
 func (DiscountApiController) Create(c echo.Context) error {
 	var v DiscountInput
 	if err := c.Bind(&v); err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	if err := c.Validate(&v); err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	discount, err := v.ToModel()
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	if _, err := discount.Create(c.Request().Context()); err != nil {
-		return c.JSON(http.StatusInternalServerError, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
 	}
-	return c.JSON(http.StatusOK, ApiResult{
-		Success: true,
-		Result:  discount,
-	})
+	return ReturnApiSucc(c, http.StatusOK, discount)
 }
 
 func (DiscountApiController) GetOne(c echo.Context) error {
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	v, err := models.Discount{}.GetById(c.Request().Context(), id)
 	if err != nil {
-		return c.JSON(http.StatusInternalServerError, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
 	}
 	if v == nil {
-		return c.JSON(http.StatusNotFound, nil)
+		return ReturnApiFail(c, http.StatusNotFound, ApiErrorNotFound, nil)
 	}
-	return c.JSON(http.StatusOK, ApiResult{
-		Success: true,
-		Result:  v,
-	})
+	return ReturnApiSucc(c, http.StatusOK, v)
 }
 
 func (DiscountApiController) Update(c echo.Context) error {
 	var v DiscountInput
 	if err := c.Bind(&v); err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	if err := c.Validate(&v); err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	discount, err := v.ToModel()
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 
 	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
 	if err != nil {
-		return c.JSON(http.StatusBadRequest, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
 	}
 	discount.Id = id
 	if err := discount.Update(c.Request().Context()); err != nil {
-		return c.JSON(http.StatusInternalServerError, ApiResult{
-			Error: ApiError{Message: err.Error()},
-		})
+		return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
 	}
-	return c.JSON(http.StatusOK, ApiResult{
-		Success: true,
-		Result:  discount,
-	})
+	return ReturnApiSucc(c, http.StatusOK, discount)
 }

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -1,6 +1,7 @@
 package controllers
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -21,13 +22,56 @@ type ApiResult struct {
 
 type ApiError struct {
 	Code    int         `json:"code,omitempty"`
-	Details interface{} `json:"details,omitempty"`
 	Message string      `json:"message,omitempty"`
+	Details interface{} `json:"details,omitempty"`
 }
 
 type ArrayResult struct {
 	Items      interface{} `json:"items"`
 	TotalCount int64       `json:"totalCount"`
+}
+
+var (
+	// System Error
+	ApiErrorSystem             = ApiError{Code: 10001, Message: "System Error"}
+	ApiErrorServiceUnavailable = ApiError{Code: 10002, Message: "Service unavailable"}
+	ApiErrorRemoteService      = ApiError{Code: 10003, Message: "Remote service error"}
+	ApiErrorIPLimit            = ApiError{Code: 10004, Message: "IP limit"}
+	ApiErrorPermissionDenied   = ApiError{Code: 10005, Message: "Permission denied"}
+	ApiErrorIllegalRequest     = ApiError{Code: 10006, Message: "Illegal request"}
+	ApiErrorHTTPMethod         = ApiError{Code: 10007, Message: "HTTP method is not suported for this request"}
+	ApiErrorParameter          = ApiError{Code: 10008, Message: "Parameter error"}
+	ApiErrorMissParameter      = ApiError{Code: 10009, Message: "Miss required parameter"}
+	ApiErrorDB                 = ApiError{Code: 10010, Message: "DB error, please contact the administator"}
+	ApiErrorTokenInvaild       = ApiError{Code: 10011, Message: "Token invaild"}
+	ApiErrorMissToken          = ApiError{Code: 10012, Message: "Miss token"}
+	ApiErrorVersion            = ApiError{Code: 10013, Message: "API version %s invalid"}
+	ApiErrorNotFound           = ApiError{Code: 10014, Message: "Resource not found"}
+	// Business Error
+	ApiErrorUserNotExists = ApiError{Code: 20001, Message: "User does not exists"}
+	ApiErrorPassword      = ApiError{Code: 20002, Message: "Password error"}
+)
+
+func ReturnApiFail(c echo.Context, status int, apiError ApiError, err error, v ...interface{}) error {
+	str := ""
+	if err != nil {
+		str = err.Error()
+	}
+	return c.JSON(status, ApiResult{
+		Success: false,
+		Error: ApiError{
+			Code:    apiError.Code,
+			Message: fmt.Sprintf(apiError.Message, v...),
+			Details: str,
+		},
+	})
+}
+
+func ReturnApiSucc(c echo.Context, status int, result interface{}) error {
+	return c.JSON(status, ApiResult{
+		Success: true,
+		Result:  result,
+	})
 }
 
 func setFlashMessage(c echo.Context, m map[string]string) {

--- a/filters/db_context.go
+++ b/filters/db_context.go
@@ -60,7 +60,7 @@ func DbContext(c config.Database) echo.MiddlewareFunc {
 				}
 				if err := next(c); err != nil {
 					session.Rollback()
-					return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
+					return err
 				}
 				if c.Response().Status >= 500 {
 					session.Rollback()
@@ -70,9 +70,7 @@ func DbContext(c config.Database) echo.MiddlewareFunc {
 					return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
 				}
 			default:
-				if err := next(c); err != nil {
-					return echo.NewHTTPError(http.StatusInternalServerError, err.Error())
-				}
+				return next(c)
 			}
 
 			return nil


### PR DESCRIPTION
I add function for api result format
Before
```
func (DiscountApiController) GetOne(c echo.Context) error {
	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
	if err != nil {
		return c.JSON(http.StatusBadRequest, ApiResult{
			Error: ApiError{Message: err.Error()},
		})
	}
	v, err := models.Discount{}.GetById(c.Request().Context(), id)
	if err != nil {
		return c.JSON(http.StatusInternalServerError, ApiResult{
			Error: ApiError{Message: err.Error()},
		})
	}
	if v == nil {
		return c.JSON(http.StatusNotFound, nil)
	}
	return c.JSON(http.StatusOK, ApiResult{
		Success: true,
		Result:  v,
	})
}
```

After
```
func (DiscountApiController) GetOne(c echo.Context) error {
	id, err := strconv.ParseInt(c.Param("id"), 10, 64)
	if err != nil {
		return ReturnApiFail(c, http.StatusBadRequest, ApiErrorParameter, err)
	}
	v, err := models.Discount{}.GetById(c.Request().Context(), id)
	if err != nil {
		return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
	}
	if v == nil {
		return ReturnApiFail(c, http.StatusNotFound, ApiErrorNotFound, nil)
	}
	return ReturnApiSucc(c, http.StatusOK, v)
}
```