### PR TITLE
Add transaction commit in API return function

### DIFF
--- a/controllers/discount_api_test.go
+++ b/controllers/discount_api_test.go
@@ -2,6 +2,7 @@ package controllers
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -91,6 +92,9 @@ func Test_DiscountApiController_GetAll_SortByAsc(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := echoApp.NewContext(req, rec)
 	test.Ok(t, handleWithFilter(DiscountApiController{}.GetAll, c))
+	if rec.Code != http.StatusOK {
+		fmt.Println(rec.Body.String())
+	}
 	test.Equals(t, http.StatusOK, rec.Code)
 
 	var v struct {
@@ -110,7 +114,9 @@ func Test_DiscountApiController_GetAll_SortByDesc(t *testing.T) {
 	rec := httptest.NewRecorder()
 	c := echoApp.NewContext(req, rec)
 	test.Ok(t, handleWithFilter(DiscountApiController{}.GetAll, c))
-	// fmt.Println(rec.Body.String())
+	if rec.Code != http.StatusOK {
+		fmt.Println(rec.Body.String())
+	}
 	test.Equals(t, http.StatusOK, rec.Code)
 
 	var v struct {

--- a/controllers/discount_api_test.go
+++ b/controllers/discount_api_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/labstack/echo"
 
@@ -63,6 +64,7 @@ func Test_DiscountApiController_Update(t *testing.T) {
 	test.Ok(t, json.Unmarshal(rec.Body.Bytes(), &v))
 	test.Equals(t, v.Result.Name, "discount name2")
 	test.Equals(t, v.Result.StartAt.Format("2006-01-02"), "2017-01-02")
+	test.Equals(t, v.Result.UpdatedAt.Format("2006-01-02"), time.Now().Format("2006-01-02"))
 }
 
 func Test_DiscountApiController_GetOne(t *testing.T) {

--- a/controllers/utils.go
+++ b/controllers/utils.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/labstack/echo"
+	"github.com/pangpanglabs/echosample/factory"
 )
 
 const (
@@ -68,6 +69,14 @@ func ReturnApiFail(c echo.Context, status int, apiError ApiError, err error, v .
 }
 
 func ReturnApiSucc(c echo.Context, status int, result interface{}) error {
+	req := c.Request()
+	if req.Method == "POST" || req.Method == "PUT" || req.Method == "DELETE" {
+		err := factory.DB(req.Context()).Commit()
+		if err != nil {
+			return ReturnApiFail(c, http.StatusInternalServerError, ApiErrorDB, err)
+		}
+	}
+
 	return c.JSON(status, ApiResult{
 		Success: true,
 		Result:  result,


### PR DESCRIPTION
Fix #2 After creating or updating, `CreateAt`, `UpdatedAt` fields are not set